### PR TITLE
fix: recover long-prompt image results

### DIFF
--- a/src/Midjourney.Base/Utils/ConservativePromptMatcher.cs
+++ b/src/Midjourney.Base/Utils/ConservativePromptMatcher.cs
@@ -1,0 +1,59 @@
+namespace Midjourney.Base.Util
+{
+    /// <summary>
+    /// Conservative fallback for Discord bot messages whose rendered prompt
+    /// was truncated. Exact message/interaction ids and exact prompt matches
+    /// must be attempted before this matcher.
+    /// </summary>
+    public static class ConservativePromptMatcher
+    {
+        public const int MinimumComparableLength = 256;
+        public const double MinimumCoverage = 0.5;
+
+        public static bool IsMatch(string submittedPrompt, string returnedPrompt)
+        {
+            var submitted = Normalize(submittedPrompt);
+            var returned = Normalize(returnedPrompt);
+            if (string.IsNullOrWhiteSpace(submitted) || string.IsNullOrWhiteSpace(returned))
+            {
+                return false;
+            }
+
+            if (submitted.Equals(returned, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            var shorter = submitted.Length <= returned.Length ? submitted : returned;
+            var longer = submitted.Length <= returned.Length ? returned : submitted;
+            shorter = TrimTruncationMarker(shorter);
+
+            if (shorter.Length < MinimumComparableLength)
+            {
+                return false;
+            }
+
+            if ((double)shorter.Length / longer.Length < MinimumCoverage)
+            {
+                return false;
+            }
+
+            return longer.StartsWith(shorter, StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static string Normalize(string prompt)
+        {
+            return MjPromptParser.Parse(prompt)?.CleanPromptNormalized?.Trim() ?? string.Empty;
+        }
+
+        private static string TrimTruncationMarker(string prompt)
+        {
+            var value = prompt.TrimEnd().TrimEnd('\u2026').TrimEnd();
+            while (value.EndsWith("...", StringComparison.Ordinal))
+            {
+                value = value[..^3].TrimEnd();
+            }
+            return value;
+        }
+    }
+}

--- a/src/Midjourney.Base/Utils/ConservativeTaskMatcher.cs
+++ b/src/Midjourney.Base/Utils/ConservativeTaskMatcher.cs
@@ -1,0 +1,39 @@
+#nullable enable
+
+using Midjourney.Base.Models;
+
+namespace Midjourney.Base.Util
+{
+    /// <summary>
+    /// Stable task correlation fallbacks for final Discord messages that no
+    /// longer carry the original message or interaction id.
+    /// </summary>
+    public static class ConservativeTaskMatcher
+    {
+        public static TaskInfo? FindUniqueBySeed(
+            IEnumerable<TaskInfo> candidates,
+            string? seed,
+            out int matchCount)
+        {
+            matchCount = 0;
+            if (string.IsNullOrWhiteSpace(seed))
+            {
+                return null;
+            }
+
+            TaskInfo? match = null;
+            foreach (var candidate in candidates)
+            {
+                if (!string.Equals(candidate.Seed, seed, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                matchCount++;
+                match = matchCount == 1 ? candidate : null;
+            }
+
+            return matchCount == 1 ? match : null;
+        }
+    }
+}

--- a/src/Midjourney.Services/DiscordWebSocketService.cs
+++ b/src/Midjourney.Services/DiscordWebSocketService.cs
@@ -4006,6 +4006,28 @@ namespace Midjourney.Services
                 }
             }
 
+            // 6. Discord may publish the final image as a new message and
+            // truncate a long rendered prompt. Match only one conservative
+            // long-prefix candidate; ambiguity must remain unmatched.
+            if (task == null)
+            {
+                var filterList = list
+                    .Where(c => !string.IsNullOrWhiteSpace(c.PromptEn)
+                        && ConservativePromptMatcher.IsMatch(c.PromptEn, fullPrompt))
+                    .ToList();
+                if (filterList.Count == 1)
+                {
+                    task = filterList[0];
+                    Log.Information("Matched image task by conservative long-prompt prefix: TaskId={@0}, MessageId={@1}",
+                        task.Id, msgId);
+                }
+                else if (filterList.Count > 1)
+                {
+                    Log.Warning("Skipped ambiguous conservative long-prompt match: Count={@0}, MessageId={@1}",
+                        filterList.Count, msgId);
+                }
+            }
+
             if (task == null || task.IsCompleted)
             {
                 return;

--- a/src/Midjourney.Services/DiscordWebSocketService.cs
+++ b/src/Midjourney.Services/DiscordWebSocketService.cs
@@ -3944,19 +3944,34 @@ namespace Midjourney.Services
                 }
 
                 var seed = parseResult.GetSeed()?.ToString();
-                var filterList = list
-                    .Where(c => !string.IsNullOrWhiteSpace(c.PromptFull) && parseResult.CleanPrompt.Equals(MjPromptParser.Parse(c.PromptFull)?.CleanPrompt, StringComparison.OrdinalIgnoreCase))
-                    .WhereIf(!string.IsNullOrWhiteSpace(seed), c => c.Seed == seed)
-                    .ToList();
-                if (filterList.Count == 1)
+                task = ConservativeTaskMatcher.FindUniqueBySeed(list, seed, out var seedMatchCount);
+                if (task != null)
                 {
-                    task = filterList.FirstOrDefault();
+                    Log.Information("Matched image task by unique seed: TaskId={@0}, MessageId={@1}, Seed={@2}",
+                        task.Id, msgId, seed);
                 }
-                else if (filterList.Count > 1)
+                else if (seedMatchCount > 1)
                 {
-                    // 根据提交时间取 1 个并记录警告日志
-                    task = filterList.OrderBy(c => c.StartTime).FirstOrDefault();
-                    Log.Warning("通过替换 URL 后的提示词找到多个种子想象/混图任务，取最早提交的一个: Count={@0}, TaskId={@1}, FullPrompt={@2}", filterList.Count, task.Id, fullPrompt);
+                    Log.Warning("Skipped ambiguous seed match: Count={@0}, MessageId={@1}, Seed={@2}",
+                        seedMatchCount, msgId, seed);
+                }
+
+                if (task == null)
+                {
+                    var filterList = list
+                        .Where(c => !string.IsNullOrWhiteSpace(c.PromptFull) && parseResult.CleanPrompt.Equals(MjPromptParser.Parse(c.PromptFull)?.CleanPrompt, StringComparison.OrdinalIgnoreCase))
+                        .WhereIf(!string.IsNullOrWhiteSpace(seed), c => c.Seed == seed)
+                        .ToList();
+                    if (filterList.Count == 1)
+                    {
+                        task = filterList.FirstOrDefault();
+                    }
+                    else if (filterList.Count > 1)
+                    {
+                        // 根据提交时间取 1 个并记录警告日志
+                        task = filterList.OrderBy(c => c.StartTime).FirstOrDefault();
+                        Log.Warning("通过替换 URL 后的提示词找到多个种子想象/混图任务，取最早提交的一个: Count={@0}, TaskId={@1}, FullPrompt={@2}", filterList.Count, task.Id, fullPrompt);
+                    }
                 }
             }
 

--- a/src/Midjourney.Tests/ConservativePromptMatcherTests.cs
+++ b/src/Midjourney.Tests/ConservativePromptMatcherTests.cs
@@ -1,0 +1,56 @@
+using Midjourney.Base.Util;
+
+namespace Midjourney.Tests
+{
+    public class ConservativePromptMatcherTests
+    {
+        [Fact]
+        public void LongBotTruncation_ShouldMatch()
+        {
+            var shared = string.Join(" ", Enumerable.Repeat(
+                "cinematic wide shot with layered atmospheric detail", 12));
+            var submitted = $"{shared} final subject detail --ar 16:9 --v 8.1";
+            var returned = $"{shared}...";
+
+            Assert.True(ConservativePromptMatcher.IsMatch(submitted, returned));
+        }
+
+        [Fact]
+        public void ShortPrefix_ShouldNotMatch()
+        {
+            Assert.False(ConservativePromptMatcher.IsMatch(
+                "cinematic portrait with soft light",
+                "cinematic portrait..."));
+        }
+
+        [Fact]
+        public void LowCoverageLongPrefix_ShouldNotMatch()
+        {
+            var returned = new string('a', 300);
+            var submitted = returned + new string('b', 400);
+
+            Assert.False(ConservativePromptMatcher.IsMatch(submitted, returned));
+        }
+
+        [Fact]
+        public void DivergentLongPrompts_ShouldNotMatch()
+        {
+            var left = string.Join(" ", Enumerable.Repeat(
+                "cinematic wide shot with layered atmospheric detail", 8));
+            var right = new string('x', left.Length);
+
+            Assert.False(ConservativePromptMatcher.IsMatch(left, right));
+        }
+
+        [Fact]
+        public void ParametersAndWhitespace_ShouldBeIgnored()
+        {
+            var shared = string.Join(" ", Enumerable.Repeat(
+                "cinematic wide shot with layered atmospheric detail", 12));
+
+            Assert.True(ConservativePromptMatcher.IsMatch(
+                $"  {shared}   --ar 16:9 --v 8.1",
+                $"{shared}..."));
+        }
+    }
+}

--- a/src/Midjourney.Tests/ConservativeTaskMatcherTests.cs
+++ b/src/Midjourney.Tests/ConservativeTaskMatcherTests.cs
@@ -1,0 +1,64 @@
+using Midjourney.Base.Models;
+using Midjourney.Base.Util;
+
+namespace Midjourney.Tests
+{
+    public class ConservativeTaskMatcherTests
+    {
+        [Fact]
+        public void UniqueSeed_ShouldMatchTaskAfterPromptRewrite()
+        {
+            var target = new TaskInfo
+            {
+                Id = "target",
+                Seed = "81989239",
+                PromptEn = "original verbose prompt --p m7478300276063993880"
+            };
+            var tasks = new[]
+            {
+                new TaskInfo { Id = "other", Seed = "1776363240" },
+                target
+            };
+
+            var match = ConservativeTaskMatcher.FindUniqueBySeed(
+                tasks, "81989239", out var matchCount);
+
+            Assert.Same(target, match);
+            Assert.Equal(1, matchCount);
+        }
+
+        [Fact]
+        public void DuplicateSeed_ShouldRemainUnmatched()
+        {
+            var tasks = new[]
+            {
+                new TaskInfo { Id = "first", Seed = "81989239" },
+                new TaskInfo { Id = "second", Seed = "81989239" }
+            };
+
+            var match = ConservativeTaskMatcher.FindUniqueBySeed(
+                tasks, "81989239", out var matchCount);
+
+            Assert.Null(match);
+            Assert.Equal(2, matchCount);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void MissingSeed_ShouldRemainUnmatched(string? seed)
+        {
+            var tasks = new[]
+            {
+                new TaskInfo { Id = "task", Seed = "81989239" }
+            };
+
+            var match = ConservativeTaskMatcher.FindUniqueBySeed(
+                tasks, seed, out var matchCount);
+
+            Assert.Null(match);
+            Assert.Equal(0, matchCount);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #72. Midjourney can emit the completed image as a new Discord message without the original message or interaction id. Personalized prompts may also be rewritten wholesale (including the --p code), so exact and prefix prompt matching both fail. This adds two conservative fallbacks after exact id/prompt matching: (1) unique seed among running tasks in the same Discord instance, then (2) long normalized prompt prefix with minimum length/coverage. Ambiguous candidates remain unmatched. Includes focused tests for prompt rewriting, seed collisions, missing seeds, truncation, low coverage, and divergent prompts.